### PR TITLE
Stop unused vars and args preventing builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-eq-author",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "eslint rules for eq-author",
   "peerDependencies": {
     "eslint": "^5.6.1"

--- a/react.js
+++ b/react.js
@@ -22,6 +22,6 @@ module.exports = {
     "react/jsx-pascal-case": "error",
 
     "babel/no-invalid-this": "error",
-    "no-unused-vars": ["error", { vars: "all", args: "after-used" }],
+    "no-unused-vars": ["warn", { vars: "all", args: "after-used" }],
   }
 }


### PR DESCRIPTION
### What is the context of this PR?
- Changes `no-unused-vars` to warn (not error) to ensure you can still build projects

### How to review 
- Use in `eq-author` and validate you can still build with unused vars or args