### PR TITLE
Removed no-named-as-default

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ module.exports = {
     "import/namespace": "error",
     "import/default": "error",
     "import/export": "error",
-    "import/no-named-as-default": "error",
     "import/no-named-as-default-member": "error",
     "import/no-duplicates": "error",
     "import/unambiguous": "error"


### PR DESCRIPTION
This no-named-as-default rule was forcing us to rename the unwrapped exports of our component files to `Unwrapped[componentName]` instead of just being export `componentName` and keep the default as is. This meant that when it came to the tests the imports could be a little confusing and the component names would be a little unwieldy. This PR allows you to export a component with the same name as the file, for example

// Foo.js
```
export class Foo extends....{

}

export default (BarWrapper)(Foo)
```

then we could import either:
```
import Foo from "./Foo"
```
for the wrapped component or

```
import { Foo } from "./Foo"
```
for the unwrapped component.

Thoughts?